### PR TITLE
[BUGFIX] JS compilation did not recover on errors

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -14,7 +14,7 @@ const $ = gulpLoadPlugins();
 const reload = browserSync.reload;
 
 export function es2015fy(entryFile, options) {
-  return () => {
+  return (done) => {
     return rollup({
       entry: entryFile,
       format: 'iife',
@@ -27,8 +27,8 @@ export function es2015fy(entryFile, options) {
           babelrc: false
         })
       ]
-    }).on('error', $.util.log)
-      .pipe(source('main.js', './src'))
+    }).on('error', done)
+      .pipe(source(entryFile))
       .pipe(buffer())
       .pipe($.sourcemaps.init({loadMaps: true}))
       .pipe($.rename(options.filename))


### PR DESCRIPTION
See Issue #11 

When `gulp serve` is active and an error occured while compiling the JS (e.g. syntax error), the watch task did not continue correctly and only ran the lint task exclusively. So you couldn’t recover from an error because no recompilation was executed.
This is fixed by explicitly calling done() on errors.
